### PR TITLE
fix: move E2E mock data out of Route Handlers to fix Cloud Run build

### DIFF
--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -2,9 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import { DEFAULT_MODEL, DEFAULT_MODEL_OPTIONS } from '@/types'
 import type { ModelOptions } from '@/types'
-
-// E2E test mock data
-export const E2E_MOCK_MESSAGES: Record<string, Array<{ id: string; conversation_id: string; role: string; content: string; created_at: string }>> = {}
+import { E2E_MOCK_MESSAGES } from '@/lib/e2e-mocks'
 
 export async function GET(
   _request: Request,

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,11 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
-
-// E2E test mock data
-const E2E_TEST_USER_ID = 'e2e-test-user-id'
-export const E2E_MOCK_CONVERSATIONS = [
-  { id: 'e2e-conv-1', user_id: E2E_TEST_USER_ID, title: 'テスト会話1', created_at: new Date().toISOString(), updated_at: new Date().toISOString() },
-]
+import { E2E_TEST_USER_ID, E2E_MOCK_CONVERSATIONS } from '@/lib/e2e-mocks'
 
 export async function GET() {
   // E2E test mode

--- a/src/app/api/conversations/search/route.ts
+++ b/src/app/api/conversations/search/route.ts
@@ -1,7 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
-import { E2E_MOCK_CONVERSATIONS } from '../route'
-import { E2E_MOCK_MESSAGES } from '../[id]/messages/route'
+import { E2E_MOCK_CONVERSATIONS, E2E_MOCK_MESSAGES } from '@/lib/e2e-mocks'
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)

--- a/src/lib/e2e-mocks.ts
+++ b/src/lib/e2e-mocks.ts
@@ -1,0 +1,9 @@
+// E2E test mock data - centralized to avoid invalid exports from Next.js Route Handlers
+
+export const E2E_TEST_USER_ID = 'e2e-test-user-id'
+
+export const E2E_MOCK_CONVERSATIONS = [
+  { id: 'e2e-conv-1', user_id: E2E_TEST_USER_ID, title: 'テスト会話1', created_at: new Date().toISOString(), updated_at: new Date().toISOString() },
+]
+
+export const E2E_MOCK_MESSAGES: Record<string, Array<{ id: string; conversation_id: string; role: string; content: string; created_at: string }>> = {}


### PR DESCRIPTION
Next.js Route Handlers only allow HTTP method exports (GET, POST, etc.). The E2E_MOCK_CONVERSATIONS and E2E_MOCK_MESSAGES exports added in PR #3 caused a type error during Docker build, breaking Cloud Run deployment.

Extracted mock data into src/lib/e2e-mocks.ts and updated all imports in the affected route handlers.

Closes #4

Generated with [Claude Code](https://claude.ai/code)