### PR TITLE
fix: モバイルでチャット入力フォームが表示されない問題を修正

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -199,7 +199,7 @@ export function ChatArea({
       </div>
 
       {/* Input */}
-      <div className="border-t border-[var(--border-color)] p-4">
+      <div className="flex-shrink-0 border-t border-[var(--border-color)] p-4 pb-[env(safe-area-inset-bottom,16px)]">
         <form onSubmit={handleSubmit} className="max-w-3xl mx-auto">
           <div className="flex gap-2 items-end">
             <div className="flex-1 relative">


### PR DESCRIPTION
- 入力エリアにflex-shrink-0を追加して縮小を防止
- iPhoneのセーフエリア対応のためpb-[env(safe-area-inset-bottom)]を追加

https://claude.ai/code/session_012z67VWha4HrvaGoQG3FLPK